### PR TITLE
Enable 36-aa input support

### DIFF
--- a/PWMpredictor/code/main_PWMpredictor.py
+++ b/PWMpredictor/code/main_PWMpredictor.py
@@ -17,6 +17,7 @@ def user_input():
     parser.add_argument('-in', '--input_file', help='input zinc finger file', type=str, required=True)
     parser.add_argument('-out', '--output_file', help='output PWN predictions file', type=str, required=True)
     parser.add_argument('-m', '--model_file', help='trained model file', type=str, required=True)
+    parser.add_argument('-res_num', '--residual_num', help='number of residues to use', type=int, default=12)
 
     args = parser.parse_args()
     arguments = vars(args)
@@ -59,7 +60,7 @@ def main(args):
 #        b1h_one_hot = np.load(main_path + 'onehot_encoding_b1h_4res.npy')
 #        b1h_pwm = np.load(main_path + 'ground_truth_b1h_pwm_4res.npy')
 
-    pipeline_model_predict(c_rc_df, args["model_file"], args["output_file"])
+    pipeline_model_predict(c_rc_df, args["model_file"], args["output_file"], args["residual_num"])
 #(b1h_one_hot, b1h_pwm, c_rc_df, zf_pred_df, args['folder_address'],
 #                   args['learning_rate'], args['epochs'], args['transfer_version'],
 #                   args['residual_num'])

--- a/PWMpredictor/code/main_loo_PWMpredictor.py
+++ b/PWMpredictor/code/main_loo_PWMpredictor.py
@@ -40,12 +40,15 @@ def main(args):
     c_rc_df = pd.read_csv(main_path + 'c_rc_df.csv', sep=' ')
     zf_pred_df = pd.read_csv(main_path + args['pred_zf_df'], sep=' ')
 
-    if args["residual_num"] == 12:
+    if args["residual_num"] == 36:
+        b1h_one_hot = np.load(main_path + 'onehot_encoding_b1h_36neigh.npy')
+        b1h_pwm = np.load(main_path + 'ground_truth_b1h_pwm_36neigh.npy')
+    elif args["residual_num"] == 12:
         b1h_one_hot = np.load(main_path + 'onehot_encoding_b1h_12res.npy')
         b1h_pwm = np.load(main_path + 'ground_truth_b1h_pwm_12res.npy')
 
 
-    if args["residual_num"] == 7:
+    elif args["residual_num"] == 7:
         if not args['amino_acid_x']:
             b1h_one_hot = np.load(main_path + 'onehot_encoding_b1h_7res.npy')
             b1h_pwm = np.load(main_path + 'ground_truth_b1h_pwm_7res.npy')
@@ -53,7 +56,7 @@ def main(args):
             b1h_one_hot = np.load(main_path + 'onehot_encoding_7b1h_res_with_ac_x.npy')
             b1h_pwm = np.load(main_path + 'ground_truth_b1h_pwm_with_ac_x.npy')
 
-    if args["residual_num"] == 4:  # residual number is equal to 4
+    elif args["residual_num"] == 4:  # residual number is equal to 4
         b1h_one_hot = np.load(main_path + 'onehot_encoding_b1h_4res.npy')
         b1h_pwm = np.load(main_path + 'ground_truth_b1h_pwm_4res.npy')
 

--- a/PWMpredictor/code/models_PWMpredictor.py
+++ b/PWMpredictor/code/models_PWMpredictor.py
@@ -11,6 +11,6 @@ def pipeline_model(b1h_input_data, b1h_label_mat, c_rc_df, zf_df, folder_address
 
     return
 
-def pipeline_model_predict(c_rc_df, model_file, output_file):
-    pipeline_func_predict(c_rc_df, model_file, output_file)
+def pipeline_model_predict(c_rc_df, model_file, output_file, res_num=12):
+    pipeline_func_predict(c_rc_df, model_file, output_file, res_num)
     return

--- a/PWMpredictor/code/utiles_loo_PWMpredictor.py
+++ b/PWMpredictor/code/utiles_loo_PWMpredictor.py
@@ -7,12 +7,17 @@ def get_label_mat(c_rc_df):
 
 
 def create_input_model(df, res_num):
-    if res_num == 12:
+    if res_num == 36:
+        oneHot_C_RC_amino = oneHot_Amino_acid_vec(df['res_36_neighbors'])
+    elif res_num == 12:
         oneHot_C_RC_amino = oneHot_Amino_acid_vec(df['res_12'])
-    if res_num == 7:
+    elif res_num == 7:
         oneHot_C_RC_amino = oneHot_Amino_acid_vec(df['res_7_b1h'])
-    if res_num == 4:  # res_num == 4
+    elif res_num == 4:  # res_num == 4
         oneHot_C_RC_amino = oneHot_Amino_acid_vec(df['res_4'])
+    else:
+        # fall back to generic res_<num> column if present
+        oneHot_C_RC_amino = oneHot_Amino_acid_vec(df[f'res_{res_num}'])
 
     return oneHot_C_RC_amino
 

--- a/PWMpredictor/code/utiles_models_PWMpredictor.py
+++ b/PWMpredictor/code/utiles_models_PWMpredictor.py
@@ -53,9 +53,23 @@ def set_trainable_layers(b1h_model, t_v):
     return
 
 
-def pipeline_func_predict(c_rc_df, model_file, output_file):
-    label_mat = (c_rc_df.filter(items=['A1', 'C1', 'G1', 'T1', 'A2', 'C2', 'G2', 'T2', 'A3', 'C3', 'G3', 'T3'])).values
-    data_model = oneHot_Amino_acid_vec(c_rc_df['res_12'])
+def pipeline_func_predict(c_rc_df, model_file, output_file, res_num=12):
+    label_mat = (
+        c_rc_df.filter(items=['A1', 'C1', 'G1', 'T1', 'A2', 'C2', 'G2', 'T2', 'A3', 'C3', 'G3', 'T3'])
+    ).values
+
+    if res_num == 36:
+        seqs = c_rc_df['res_36_neighbors']
+    elif res_num == 12:
+        seqs = c_rc_df['res_12']
+    elif res_num == 7:
+        seqs = c_rc_df['res_7_b1h']
+    elif res_num == 4:
+        seqs = c_rc_df['res_4']
+    else:
+        seqs = c_rc_df[f'res_{res_num}']
+
+    data_model = oneHot_Amino_acid_vec(seqs)
     model = keras.models.load_model(model_file)
     y_predicted = model.predict(data_model).flatten()
     np.savetxt(output_file, y_predicted)
@@ -77,8 +91,22 @@ def pipeline_func(c_rc_df, zf_df, b1h_model, folder_address, lr, epochs, res_num
 #        data_input_model = create_input_model(c_rc_df[c_rc_df['groups'] != i], res_num)
 #        data_test_model = create_input_model(zf_df[zf_df['groups'] == i], res_num)
 
-    label_mat = (c_rc_df.filter(items=['A1', 'C1', 'G1', 'T1', 'A2', 'C2', 'G2', 'T2', 'A3', 'C3', 'G3', 'T3'])).values
-    data_model = oneHot_Amino_acid_vec(c_rc_df['res_12'])
+    label_mat = (
+        c_rc_df.filter(items=['A1', 'C1', 'G1', 'T1', 'A2', 'C2', 'G2', 'T2', 'A3', 'C3', 'G3', 'T3'])
+    ).values
+
+    if res_num == 36:
+        seqs = c_rc_df['res_36_neighbors']
+    elif res_num == 12:
+        seqs = c_rc_df['res_12']
+    elif res_num == 7:
+        seqs = c_rc_df['res_7_b1h']
+    elif res_num == 4:
+        seqs = c_rc_df['res_4']
+    else:
+        seqs = c_rc_df[f'res_{res_num}']
+
+    data_model = oneHot_Amino_acid_vec(seqs)
 
 #        x_train, x_test = data_input_model, data_test_model
 #        y_train, y_test = np.asarray(label_mat), np.asarray(label_test)


### PR DESCRIPTION
## Summary
- allow utilities to load 36-residue neighbour strings
- parameterise prediction pipeline to select residue window length
- add CLI option for residue length in `main_PWMpredictor.py`
- extend LOOCV training script to work with 36-residue data

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684dc3b7bd7c83309951df4fcbcc968a